### PR TITLE
Release 1.0.1

### DIFF
--- a/Block/Adminhtml/Customer/Customersegment.php
+++ b/Block/Adminhtml/Customer/Customersegment.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Block\Adminhtml\Customer;
+
+use Juashyam\EasyAdminGrids\Model\System\Configuration;
+use Magento\Backend\Block\Widget\Button;
+
+/**
+ * Extend the grid container block of customer segment to display conditionally
+ */
+class Customersegment extends \Magento\CustomerSegment\Block\Adminhtml\Customersegment
+{
+    /**
+     * @return string
+     */
+    public function getGridHtml()
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_CUSTOMER_SEGMENT_LISTING)
+        ) {
+            return '';
+        }
+
+        return parent::getGridHtml();
+    }
+
+    /**
+     * Check whether button rendering is allowed in current context
+     *
+     * @param \Magento\Backend\Block\Widget\Button\Item $item
+     * @return bool
+     */
+    public function canRender(Button\Item $item)
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_CUSTOMER_SEGMENT_LISTING)
+        ) {
+            return false;
+        }
+
+        return parent::canRender($item);
+    }
+}

--- a/Block/Adminhtml/Marketing/CartRule.php
+++ b/Block/Adminhtml/Marketing/CartRule.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing;
+
+use Juashyam\EasyAdminGrids\Model\System\Configuration;
+use Magento\Backend\Block\Widget\Button;
+
+/**
+ * Extend the grid container block of cart rules to display conditionally
+ */
+class CartRule extends \Magento\SalesRule\Block\Adminhtml\Promo\Quote
+{
+    /**
+     * @return string
+     */
+    public function getGridHtml()
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_CART_RULE_LISTING)
+        ) {
+            return '';
+        }
+
+        return parent::getGridHtml();
+    }
+
+    /**
+     * Check whether button rendering is allowed in current context
+     *
+     * @param \Magento\Backend\Block\Widget\Button\Item $item
+     * @return bool
+     */
+    public function canRender(Button\Item $item)
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_CART_RULE_LISTING)
+        ) {
+            return false;
+        }
+
+        return parent::canRender($item);
+    }
+}

--- a/Block/Adminhtml/Marketing/CatalogRule.php
+++ b/Block/Adminhtml/Marketing/CatalogRule.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing;
+
+use Juashyam\EasyAdminGrids\Model\System\Configuration;
+use Magento\Backend\Block\Widget\Button;
+
+/**
+ * Extend the grid container block of catalog rules to display conditionally
+ */
+class CatalogRule extends \Magento\CatalogRule\Block\Adminhtml\Promo\Catalog
+{
+    /**
+     * @return string
+     */
+    public function getGridHtml()
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_CATALOG_RULE_LISTING)
+        ) {
+            return '';
+        }
+
+        return parent::getGridHtml();
+    }
+
+    /**
+     * Check whether button rendering is allowed in current context
+     *
+     * @param \Magento\Backend\Block\Widget\Button\Item $item
+     * @return bool
+     */
+    public function canRender(Button\Item $item)
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_CATALOG_RULE_LISTING)
+        ) {
+            return false;
+        }
+
+        return parent::canRender($item);
+    }
+}

--- a/Block/Adminhtml/Marketing/Giftcardaccount.php
+++ b/Block/Adminhtml/Marketing/Giftcardaccount.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing;
+
+use Juashyam\EasyAdminGrids\Model\System\Configuration;
+use Magento\Backend\Block\Widget\Button;
+
+class Giftcardaccount extends \Magento\GiftCardAccount\Block\Adminhtml\Giftcardaccount
+{
+    /**
+     * @return string
+     */
+    public function getGridHtml()
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_GIFT_ACC_RULE_LISTING)
+        ) {
+            return '';
+        }
+
+        return parent::getGridHtml();
+    }
+
+    /**
+     * Check whether button rendering is allowed in current context
+     *
+     * @param \Magento\Backend\Block\Widget\Button\Item $item
+     * @return bool
+     */
+    public function canRender(Button\Item $item)
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_GIFT_ACC_RULE_LISTING)
+        ) {
+            return false;
+        }
+
+        return parent::canRender($item);
+    }
+}

--- a/Block/Adminhtml/Marketing/Targetrule.php
+++ b/Block/Adminhtml/Marketing/Targetrule.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing;
+
+use Juashyam\EasyAdminGrids\Model\System\Configuration;
+use Magento\Backend\Block\Widget\Button;
+
+/**
+ * Extend the grid container block of related product rules to display conditionally
+ */
+class Targetrule extends \Magento\TargetRule\Block\Adminhtml\Targetrule
+{
+    /**
+     * @return string
+     */
+    public function getGridHtml()
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_RELATED_RULE_LISTING)
+        ) {
+            return '';
+        }
+
+        return parent::getGridHtml();
+    }
+
+    /**
+     * Check whether button rendering is allowed in current context
+     *
+     * @param \Magento\Backend\Block\Widget\Button\Item $item
+     * @return bool
+     */
+    public function canRender(Button\Item $item)
+    {
+        if ($this->_scopeConfig->isSetFlag(Configuration::XML_PATH_IS_ENABLED)
+            && $this->_scopeConfig->isSetFlag(Configuration::XML_PATH_REPLACE_MARKETING_RELATED_RULE_LISTING)
+        ) {
+            return false;
+        }
+
+        return parent::canRender($item);
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [1.0.1] - 2021-06-30
+### Added
+- Extends coverage of native grids under **Customers**
+    - Replace `Now Online` Grid
+    - Replace `Customers Group` Grid
+    - Replace `Customers Segment` Grid
+- Extends coverage of native grids under **Marketing**
+    - Replace `Catalog Price Rule` Grid
+    - Replace `Related Products Rules` Grid
+    - Replace `Cart Price Rules` Grid
+    - Replace `Gift Card Accounts` Grid
+- New system configurations to enable/displace Hyva Admin grid replacement
+
+### Changed
+- Restructured the directory path for listing visibility classes to group relative ones
+
+### Removed
+- Nothing
+
+## [1.0.0] - 2021-06-22
+### Added
+- Base module to replace native Admin grids with the Hyva Admin Grid
+- Replace `Blocks` Grid under **Content**
+- Replace `Pages` Grid under **Content**
+- Replace `All Customers` Grid under **Customers**
+- New system configuration to enable/disable  Easy Admin Grid
+    - Admin → Stores → Configuration → JUASHYAM → Easy Admin Grids

--- a/Model/Condition/ListingVisibility.php
+++ b/Model/Condition/ListingVisibility.php
@@ -8,6 +8,9 @@ use Magento\Framework\View\Layout\Condition\VisibilityConditionInterface;
 
 abstract class ListingVisibility implements VisibilityConditionInterface
 {
+    /**
+     * @var Configuration
+     */
     public $configuration;
 
     /**

--- a/Model/Condition/ListingVisibility/Cms/CanViewNativeCmsBlock.php
+++ b/Model/Condition/ListingVisibility/Cms/CanViewNativeCmsBlock.php
@@ -1,21 +1,21 @@
 <?php
 declare(strict_types=1);
 
-namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
+namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Cms;
 
 use Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
 
 /**
- * Dynamic validator for Customer listing page, control listing visibility.
+ * Dynamic validator for CMS block, control listing visibility.
  */
-class CanViewNativeCustomerListing extends ListingVisibility
+class CanViewNativeCmsBlock extends ListingVisibility
 {
     /**
      * Unique condition name.
      *
      * @var string
      */
-    const CONDITION_NAME = 'can_view_native_customer_listing';
+    const CONDITION_NAME = 'can_view_native_cms_block';
 
     /**
      * Validate logical condition for ui component
@@ -24,7 +24,7 @@ class CanViewNativeCustomerListing extends ListingVisibility
      */
     public function isVisible(array $arguments): bool
     {
-        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCustomerListing()) {
+        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCmsBlock()) {
             return false;
         }
 

--- a/Model/Condition/ListingVisibility/Cms/CanViewNativeCmsPage.php
+++ b/Model/Condition/ListingVisibility/Cms/CanViewNativeCmsPage.php
@@ -1,21 +1,21 @@
 <?php
 declare(strict_types=1);
 
-namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
+namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Cms;
 
 use Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
 
 /**
- * Dynamic validator for CMS block, control listing visibility.
+ * Dynamic validator for CMS page, control listing visibility.
  */
-class CanViewNativeCmsBlock extends ListingVisibility
+class CanViewNativeCmsPage extends ListingVisibility
 {
     /**
      * Unique condition name.
      *
      * @var string
      */
-    const CONDITION_NAME = 'can_view_native_cms_block';
+    const CONDITION_NAME = 'can_view_native_cms_page';
 
     /**
      * Validate logical condition for ui component
@@ -24,7 +24,7 @@ class CanViewNativeCmsBlock extends ListingVisibility
      */
     public function isVisible(array $arguments): bool
     {
-        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCmsBlock()) {
+        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCmsPage()) {
             return false;
         }
 

--- a/Model/Condition/ListingVisibility/Customer/CanViewNativeCustomerGroupListing.php
+++ b/Model/Condition/ListingVisibility/Customer/CanViewNativeCustomerGroupListing.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Customer;
+
+use Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
+
+/**
+ * Dynamic validator for Customer Group listing page, control listing visibility.
+ */
+class CanViewNativeCustomerGroupListing extends ListingVisibility
+{
+    /**
+     * Unique condition name.
+     *
+     * @var string
+     */
+    const CONDITION_NAME = 'can_view_native_customer_group_listing';
+
+    /**
+     * Validate logical condition for ui component
+     *
+     * @param array $arguments Attributes from element node.
+     */
+    public function isVisible(array $arguments): bool
+    {
+        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCustomerGroupListing()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get condition name
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return self::CONDITION_NAME;
+    }
+}

--- a/Model/Condition/ListingVisibility/Customer/CanViewNativeCustomerListing.php
+++ b/Model/Condition/ListingVisibility/Customer/CanViewNativeCustomerListing.php
@@ -1,21 +1,21 @@
 <?php
 declare(strict_types=1);
 
-namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
+namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Customer;
 
 use Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
 
 /**
- * Dynamic validator for CMS page, control listing visibility.
+ * Dynamic validator for Customer listing page, control listing visibility.
  */
-class CanViewNativeCmsPage extends ListingVisibility
+class CanViewNativeCustomerListing extends ListingVisibility
 {
     /**
      * Unique condition name.
      *
      * @var string
      */
-    const CONDITION_NAME = 'can_view_native_cms_page';
+    const CONDITION_NAME = 'can_view_native_customer_listing';
 
     /**
      * Validate logical condition for ui component
@@ -24,7 +24,7 @@ class CanViewNativeCmsPage extends ListingVisibility
      */
     public function isVisible(array $arguments): bool
     {
-        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCmsPage()) {
+        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCustomerListing()) {
             return false;
         }
 

--- a/Model/Condition/ListingVisibility/Customer/CanViewNativeCustomerOnlineListing.php
+++ b/Model/Condition/ListingVisibility/Customer/CanViewNativeCustomerOnlineListing.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Customer;
+
+use Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility;
+
+/**
+ * Dynamic validator for Customer online listing page, control listing visibility.
+ */
+class CanViewNativeCustomerOnlineListing extends ListingVisibility
+{
+    /**
+     * Unique condition name.
+     *
+     * @var string
+     */
+    const CONDITION_NAME = 'can_view_native_customer_online_listing';
+
+    /**
+     * Validate logical condition for ui component
+     *
+     * @param array $arguments Attributes from element node.
+     */
+    public function isVisible(array $arguments): bool
+    {
+        if ($this->configuration->isEnabled() && $this->configuration->canReplaceCustomerNowOnlineListing()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get condition name
+     *
+     * @return string
+     */
+    public function getName(): string
+    {
+        return self::CONDITION_NAME;
+    }
+}

--- a/Model/Config/Source/GiftCardAccountStatus.php
+++ b/Model/Config/Source/GiftCardAccountStatus.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\GiftCardAccount\Model\Giftcardaccount;
+
+/**
+ * Gift Card Account Status options
+ */
+class GiftCardAccountStatus implements OptionSourceInterface
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @inheritdoc
+     */
+    public function toOptionArray()
+    {
+        if (!$this->options) {
+            $this->options = [
+                ['value' => Giftcardaccount::STATE_AVAILABLE, 'label' => __('Available')],
+                ['value' => Giftcardaccount::STATE_USED, 'label' => __('Used')],
+                ['value' => Giftcardaccount::STATE_REDEEMED, 'label' => __('Redeemed')],
+                ['value' => Giftcardaccount::STATE_EXPIRED, 'label' => __('Expired')]
+            ];
+        }
+
+        return $this->options;
+    }
+}

--- a/Model/Config/Source/TargetRuleApplies.php
+++ b/Model/Config/Source/TargetRuleApplies.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Juashyam\EasyAdminGrids\Model\Config\Source;
+
+use Magento\Framework\Data\OptionSourceInterface;
+use Magento\TargetRule\Model\Rule;
+
+/**
+ * Target Rule applies to options
+ */
+class TargetRuleApplies implements OptionSourceInterface
+{
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @inheritdoc
+     */
+    public function toOptionArray()
+    {
+        if (!$this->options) {
+            $this->options = [
+                ['value' => Rule::RELATED_PRODUCTS, 'label' => __('Related Products')],
+                ['value' => Rule::UP_SELLS, 'label' => __('Up-sells')],
+                ['value' => Rule::CROSS_SELLS, 'label' => __('Cross-sells')]
+            ];
+        }
+
+        return $this->options;
+    }
+}

--- a/Model/System/Configuration.php
+++ b/Model/System/Configuration.php
@@ -4,14 +4,21 @@ declare(strict_types=1);
 namespace Juashyam\EasyAdminGrids\Model\System;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use \Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\ScopeInterface;
 
 class Configuration
 {
+    /**@#+
+     * @const string System Configuration Path
+     */
     const XML_PATH_IS_ENABLED = "easy_admin_grids/configuration/enabled";
     const XML_PATH_REPLACE_CMS_BLOCK = "easy_admin_grids/cms/replace_block";
     const XML_PATH_REPLACE_CMS_PAGE = "easy_admin_grids/cms/replace_page";
     const XML_PATH_REPLACE_CUSTOMER_LISTING = "easy_admin_grids/customer/replace_listing";
+    const XML_PATH_REPLACE_CUSTOMER_NOW_ONLINE_LISTING = "easy_admin_grids/customer/replace_now_online";
+    const XML_PATH_REPLACE_CUSTOMER_GROUP_LISTING = "easy_admin_grids/customer/replace_group";
+    const XML_PATH_REPLACE_CUSTOMER_SEGMENT_LISTING = "easy_admin_grids/customer/replace_segment";
+    /**#@-*/
 
     /**
      * @var ScopeConfigInterface
@@ -66,6 +73,39 @@ class Configuration
     {
         return $this->scopeConfig->getValue(
             self::XML_PATH_REPLACE_CUSTOMER_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceCustomerNowOnlineListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_CUSTOMER_NOW_ONLINE_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceCustomerGroupListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_CUSTOMER_GROUP_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceCustomerSegmentListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_CUSTOMER_SEGMENT_LISTING,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/Model/System/Configuration.php
+++ b/Model/System/Configuration.php
@@ -18,6 +18,10 @@ class Configuration
     const XML_PATH_REPLACE_CUSTOMER_NOW_ONLINE_LISTING = "easy_admin_grids/customer/replace_now_online";
     const XML_PATH_REPLACE_CUSTOMER_GROUP_LISTING = "easy_admin_grids/customer/replace_group";
     const XML_PATH_REPLACE_CUSTOMER_SEGMENT_LISTING = "easy_admin_grids/customer/replace_segment";
+    const XML_PATH_REPLACE_MARKETING_CATALOG_RULE_LISTING = "easy_admin_grids/marketing/replace_catalog_rule";
+    const XML_PATH_REPLACE_MARKETING_RELATED_RULE_LISTING = "easy_admin_grids/marketing/replace_related_product_rule";
+    const XML_PATH_REPLACE_MARKETING_CART_RULE_LISTING = "easy_admin_grids/marketing/replace_cart_rule";
+    const XML_PATH_REPLACE_MARKETING_GIFT_ACC_RULE_LISTING = "easy_admin_grids/marketing/replace_giftacc_rule";
     /**#@-*/
 
     /**
@@ -106,6 +110,50 @@ class Configuration
     {
         return $this->scopeConfig->getValue(
             self::XML_PATH_REPLACE_CUSTOMER_SEGMENT_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceMarketingCatalogRuleListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_MARKETING_CATALOG_RULE_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceMarketingRelatedRuleListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_MARKETING_RELATED_RULE_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceMarketingCartRuleListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_MARKETING_CART_RULE_LISTING,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    /**
+     * @return mixed
+     */
+    public function canReplaceMarketingGiftAccountListing()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_REPLACE_MARKETING_GIFT_ACC_RULE_LISTING,
             ScopeInterface::SCOPE_STORE
         );
     }

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ As of now, this module replaces following native grids out of the box.
   - Pages
 - Customers (Admin → Customers)
   - All Customers
-
-## To Do List
-- Customers (Admin → Customers)
   - Customers Now Online
   - Customer Segments
   - Customer Groups
+
+## To Do List
 - Marketing (Admin → Marketing)
   - Cart Price Rules
   - Catalog Price Rule

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ As of now, this module replaces following native grids out of the box.
   - Customers Now Online
   - Customer Segments
   - Customer Groups
-
-## To Do List
 - Marketing (Admin → Marketing)
   - Cart Price Rules
   - Catalog Price Rule

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -5,5 +5,6 @@
             <argument name="gridTemplate" xsi:type="string">Hyva_Admin::grid.phtml</argument>
         </arguments>
     </type>
+    <preference for="Magento\SalesRule\Block\Adminhtml\Promo\Quote" type="Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing\CartRule"/>
 </config>
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -36,6 +36,21 @@
                     <comment><![CDATA[Replace the native Customers Grid with the Easy Admin Grid.]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="replace_now_online" translate="label" type="select" sortOrder="2" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Customers Now Online Grid</label>
+                    <comment><![CDATA[Replace the native Customers Now Online Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="replace_group" translate="label" type="select" sortOrder="3" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Customers Group Grid</label>
+                    <comment><![CDATA[Replace the native Customers Group Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="replace_segment" translate="label" type="select" sortOrder="4" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Customers Segment Grid</label>
+                    <comment><![CDATA[Replace the native Customers Segment Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -52,6 +52,29 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
+            <group id="marketing" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="0" showInStore="0">
+                <label>Marketing</label>
+                <field id="replace_catalog_rule" translate="label" type="select" sortOrder="1" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Catalog Price Rule Grid</label>
+                    <comment><![CDATA[Replace the native Catalog Price Rule Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="replace_related_product_rule" translate="label" type="select" sortOrder="2" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Related Products Rules Grid</label>
+                    <comment><![CDATA[Replace the native Related Products Rules Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="replace_cart_rule" translate="label" type="select" sortOrder="3" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Cart Price Rules Grid</label>
+                    <comment><![CDATA[Replace the native Cart Price Rules Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+                <field id="replace_giftacc_rule" translate="label" type="select" sortOrder="4" showInDefault="1" showInStore="0" showInWebsite="0">
+                    <label>Replace Gift Card Accounts Grid</label>
+                    <comment><![CDATA[Replace the native Gift Card Accounts Grid with the Easy Admin Grid.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
         </section>
     </system>
 </config>

--- a/view/adminhtml/hyva-grid/customer-group-grid.xml
+++ b/view/adminhtml/hyva-grid/customer-group-grid.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <collection>\Magento\Customer\Model\ResourceModel\Group\Grid\Collection</collection>
+    </source>
+    <columns>
+        <include>
+            <column name="customer_group_id" label="ID"/>
+            <column name="customer_group_code" label="Group"/>
+            <column name="tax_class_id" label="Tax Class" source="\Magento\Tax\Model\TaxClass\Source\Customer"/>
+        </include>
+    </columns>
+    <actions idColumn="customer_group_id">
+        <action id="edit" label="Edit" url="customer/group/edit" idParam="id"/>
+    </actions>
+    <entityConfig>
+        <label>
+            <singular>Customer Group</singular>
+            <plural>Customer Groups</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <buttons>
+            <button id="new" label="Add New Customer Group" url="customer/group/new/"/>
+        </buttons>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>customer_group_id</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="customer_group_id"/>
+            <filter column="customer_group_code"/>
+            <filter column="tax_class_id"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/hyva-grid/customer-online-grid.xml
+++ b/view/adminhtml/hyva-grid/customer-online-grid.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <query>
+            <select>
+                <from table="customer_visitor" as="main_table"/>
+                <join type="inner" table="customer_entity" as="customer">
+                    <on>customer.entity_id = main_table.customer_id</on>
+                    <columns>
+                        <column name="main_table.visitor_id" as="visitor_id"/>
+                        <column name="customer.firstname" as="firstname"/>
+                        <column name="customer.lastname" as="lastname"/>
+                        <column name="customer.email" as="email"/>
+                        <column name="main_table.last_visit_at" as="last_visit_at"/>
+                        <expression as="visitor_type">IF((main_table.customer_id IS NOT NULL AND main_table.customer_id != 0), "c", "v")</expression>
+                    </columns>
+                </join>
+            </select>
+        </query>
+    </source>
+    <columns>
+        <include>
+            <column name="visitor_id" label="ID" type="int"/>
+            <column name="firstname" label="First Name"/>
+            <column name="lastname" label="Last Name"/>
+            <column name="email"/>
+            <column name="last_visit_at" label="Last Activity" type="string"/>
+            <column name="visitor_type" label="Type" source="\Magento\Customer\Ui\Component\Listing\Column\Online\Type\Options"/>
+        </include>
+    </columns>
+    <entityConfig>
+        <label>
+            <singular>Customers Now Online</singular>
+            <plural>Customers Now Online</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>visitor_id</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="visitor_id"/>
+            <filter column="firstname"/>
+            <filter column="lastname"/>
+            <filter column="email"/>
+            <filter column="last_visit_at" filterType="\Hyva\Admin\Model\GridFilter\DateRangeFilter"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/hyva-grid/customer-segment-grid.xml
+++ b/view/adminhtml/hyva-grid/customer-segment-grid.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <collection>\Magento\CustomerSegment\Model\ResourceModel\Segment\Collection</collection>
+    </source>
+    <columns>
+        <include>
+            <column name="segment_id" label="ID"/>
+            <column name="name" label="Segment"/>
+            <column name="is_active" label="Status">
+                <option value="1" label="Active"/>
+                <option value="0" label="Inactive"/>
+            </column>
+            <column name="website_ids" label="Web Site" type="website_id" source="Magento\Store\Model\ResourceModel\Website\Collection"/>
+        </include>
+    </columns>
+    <actions idColumn="segment_id">
+        <action id="edit" label="Edit" url="customersegment/index/edit" idParam="id"/>
+    </actions>
+    <entityConfig>
+        <label>
+            <singular>Customer Segment</singular>
+            <plural>Customer Segments</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <buttons>
+            <button id="new" label="Add Segment" url="customersegment/index/new/"/>
+        </buttons>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>segment_id</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="segment_id"/>
+            <filter column="name"/>
+            <filter column="is_active"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/hyva-grid/marketing-cart-rules-grid.xml
+++ b/view/adminhtml/hyva-grid/marketing-cart-rules-grid.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <collection>\Magento\SalesRule\Model\ResourceModel\Rule\Quote\Collection</collection>
+    </source>
+    <columns>
+        <include>
+            <column name="rule_id" label="ID"/>
+            <column name="name" label="Rule"/>
+            <column name="code" label="Coupon Code"/>
+            <column name="sort_order" label="Priority"/>
+            <column name="is_active" label="Status">
+                <option value="1" label="Active"/>
+                <option value="0" label="Inactive"/>
+            </column>
+            <column name="website_ids" label="Web Site" type="website_id" source="\Magento\Store\Model\ResourceModel\Website\Collection"/>
+        </include>
+    </columns>
+    <actions idColumn="rule_id">
+        <action id="edit" label="Edit" url="sales_rule/promo_quote/edit/" idParam="id"/>
+    </actions>
+    <entityConfig>
+        <label>
+            <singular>Cart Price Rule</singular>
+            <plural>Cart Price Rules</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <buttons>
+            <button id="new" label="Add New Rule" url="sales_rule/promo_quote/new/"/>
+        </buttons>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>sort_order</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="rule_id"/>
+            <filter column="name"/>
+            <filter column="code"/>
+            <filter column="sort_order"/>
+            <filter column="is_active"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/hyva-grid/marketing-cart-rules-grid.xml
+++ b/view/adminhtml/hyva-grid/marketing-cart-rules-grid.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0"?>
 <grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
     <source>
-        <collection>\Magento\SalesRule\Model\ResourceModel\Rule\Quote\Collection</collection>
+        <repositoryListMethod>\Magento\SalesRule\Api\RuleRepositoryInterface::getList</repositoryListMethod>
     </source>
     <columns>
         <include>
             <column name="rule_id" label="ID"/>
             <column name="name" label="Rule"/>
-            <column name="code" label="Coupon Code"/>
             <column name="sort_order" label="Priority"/>
             <column name="is_active" label="Status">
                 <option value="1" label="Active"/>
@@ -40,7 +39,6 @@
         <filters>
             <filter column="rule_id"/>
             <filter column="name"/>
-            <filter column="code"/>
             <filter column="sort_order"/>
             <filter column="is_active"/>
         </filters>

--- a/view/adminhtml/hyva-grid/marketing-catalog-rules-grid.xml
+++ b/view/adminhtml/hyva-grid/marketing-catalog-rules-grid.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <collection>\Magento\CatalogRule\Model\ResourceModel\Grid\Collection</collection>
+    </source>
+    <columns>
+        <include>
+            <column name="rule_id" label="ID"/>
+            <column name="name" label="Rule"/>
+            <column name="sort_order" label="Priority"/>
+            <column name="website_ids" label="Web Site" type="website_id" source="Magento\Store\Model\ResourceModel\Website\Collection"/>
+        </include>
+    </columns>
+    <actions idColumn="rule_id">
+        <action id="edit" label="Edit" url="catalog_rule/promo_catalog/edit" idParam="id"/>
+    </actions>
+    <entityConfig>
+        <label>
+            <singular>Catalog Price Rule</singular>
+            <plural>Catalog Price Rules</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <buttons>
+            <button id="new" label="Add New Rule" url="catalog_rule/promo_catalog/new/"/>
+        </buttons>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>name</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="rule_id" filterType="\Hyva\Admin\Model\GridFilter\ValueRangeFilter"/>
+            <filter column="name"/>
+            <filter column="sort_order"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/hyva-grid/marketing-gift-account-grid.xml
+++ b/view/adminhtml/hyva-grid/marketing-gift-account-grid.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <collection>\Magento\GiftCardAccount\Model\ResourceModel\Giftcardaccount\Collection</collection>
+    </source>
+    <columns>
+        <include>
+            <column name="giftcardaccount_id" label="ID"/>
+            <column name="code"/>
+            <column name="website_id" label="Website" type="website_id" source="Magento\Store\Model\ResourceModel\Website\Collection"/>
+            <column name="date_created" label="Created"/>
+            <column name="date_expires" label="End"/>
+            <column name="status" label="Active" source="\Magento\Config\Model\Config\Source\Yesno"/>
+            <column name="state" label="Status" source="\Juashyam\EasyAdminGrids\Model\Config\Source\GiftCardAccountStatus"/>
+            <column name="balance" label="Balance"/>
+        </include>
+    </columns>
+    <actions idColumn="giftcardaccount_id">
+        <action id="edit" label="Edit" url="admin/giftcardaccount/edit/" idParam="id"/>
+    </actions>
+    <entityConfig>
+        <label>
+            <singular>Gift Card Account</singular>
+            <plural>Gift Card Accounts</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <buttons>
+            <button id="new" label="Add Gift Card Account" url="admin/giftcardaccount/new/"/>
+        </buttons>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>giftcardaccount_id</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="giftcardaccount_id"/>
+            <filter column="code"/>
+            <filter column="date_created" filterType="\Hyva\Admin\Model\GridFilter\DateRangeFilter"/>
+            <filter column="date_expires" filterType="\Hyva\Admin\Model\GridFilter\DateRangeFilter"/>
+            <filter column="status"/>
+            <filter column="state"/>
+            <filter column="balance" filterType="\Hyva\Admin\Model\GridFilter\ValueRangeFilter"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/hyva-grid/marketing-related-rules-grid.xml
+++ b/view/adminhtml/hyva-grid/marketing-related-rules-grid.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<grid xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Hyva_Admin:etc/hyva-grid.xsd">
+    <source>
+        <query>
+            <select>
+                <from table="magento_targetrule" as="main_table"/>
+                <columns>
+                    <column name="rule_id"/>
+                    <column name="name"/>
+                    <column name="sort_order"/>
+                    <column name="apply_to"/>
+                    <column name="is_active"/>
+                    <expression as="from_date">IF((from_date IS NOT NULL), from_date, "--")</expression>
+                    <expression as="to_date">IF((to_date IS NOT NULL), to_date, "--")</expression>
+                </columns>
+            </select>
+        </query>
+    </source>
+    <columns>
+        <include>
+            <column name="rule_id" label="ID"/>
+            <column name="name" label="Rule"/>
+            <column name="from_date" label="Start"/>
+            <column name="to_date" label="End"/>
+            <column name="sort_order" label="Priority"/>
+            <column name="apply_to" label="Applies To" source="\Juashyam\EasyAdminGrids\Model\Config\Source\TargetRuleApplies"/>
+            <column name="is_active" label="Status">
+                <option value="1" label="Active"/>
+                <option value="0" label="Inactive"/>
+            </column>
+        </include>
+    </columns>
+    <actions idColumn="rule_id">
+        <action id="edit" label="Edit" url="admin/targetrule/edit/" idParam="id"/>
+    </actions>
+    <entityConfig>
+        <label>
+            <singular>Related Products Rule</singular>
+            <plural>Related Products Rules</plural>
+        </label>
+    </entityConfig>
+    <navigation>
+        <buttons>
+            <button id="new" label="Add Rule" url="admin/targetrule/new/"/>
+        </buttons>
+        <pager>
+            <defaultPageSize>20</defaultPageSize>
+            <pageSizes>20,30,50,100,200</pageSizes>
+        </pager>
+        <sorting>
+            <defaultSortByColumn>name</defaultSortByColumn>
+            <defaultSortDirection>asc</defaultSortDirection>
+        </sorting>
+        <filters>
+            <filter column="rule_id"/>
+            <filter column="name"/>
+            <filter column="from_date" filterType="\Hyva\Admin\Model\GridFilter\DateRangeFilter"/>
+            <filter column="to_date" filterType="\Hyva\Admin\Model\GridFilter\DateRangeFilter"/>
+            <filter column="sort_order"/>
+            <filter column="apply_to"/>
+            <filter column="is_active"/>
+        </filters>
+    </navigation>
+</grid>

--- a/view/adminhtml/layout/adminhtml_giftcardaccount_index.xml
+++ b/view/adminhtml/layout/adminhtml_giftcardaccount_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing\Giftcardaccount" name="adminhtml.gift.card.account.grid.container" as="giftcardaccount_list"/>
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="marketing-gift-account-grid" ifconfig="easy_admin_grids/marketing/replace_giftacc_rule">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">marketing-gift-account-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/adminhtml_targetrule_index.xml
+++ b/view/adminhtml/layout/adminhtml_targetrule_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing\Targetrule" name="adminhtml.targetrule.grid.container"/>
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="marketing-related-rules-grid" ifconfig="easy_admin_grids/marketing/replace_related_product_rule">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">marketing-related-rules-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/catalog_rule_promo_catalog_index.xml
+++ b/view/adminhtml/layout/catalog_rule_promo_catalog_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Marketing\CatalogRule" name="adminhtml.promo.catalog.grid.container"/>
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="marketing-catalog-rules-grid" ifconfig="easy_admin_grids/marketing/replace_catalog_rule">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">marketing-catalog-rules-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/cms_block_index.xml
+++ b/view/adminhtml/layout/cms_block_index.xml
@@ -4,7 +4,7 @@
     <body>
         <referenceContainer name="content">
             <uiComponent name="cms_block_listing">
-                <visibilityCondition name="can_view_native_cms_block" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\CanViewNativeCmsBlock"/>
+                <visibilityCondition name="can_view_native_cms_block" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Cms\CanViewNativeCmsBlock"/>
             </uiComponent>
             <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="cms-block-grid" ifconfig="easy_admin_grids/cms/replace_block">
                 <arguments>

--- a/view/adminhtml/layout/cms_page_index.xml
+++ b/view/adminhtml/layout/cms_page_index.xml
@@ -4,7 +4,7 @@
     <body>
         <referenceContainer name="content">
             <uiComponent name="cms_page_listing">
-                <visibilityCondition name="can_view_native_cms_page" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\CanViewNativeCmsPage"/>
+                <visibilityCondition name="can_view_native_cms_page" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Cms\CanViewNativeCmsPage"/>
             </uiComponent>
             <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="cms-page-grid" ifconfig="easy_admin_grids/cms/replace_page">
                 <arguments>

--- a/view/adminhtml/layout/customer_group_index.xml
+++ b/view/adminhtml/layout/customer_group_index.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="customer_group_listing">
+                <visibilityCondition name="can_view_native_customer_group_listing" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Customer\CanViewNativeCustomerGroupListing"/>
+            </uiComponent>
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="customer-group-grid" ifconfig="easy_admin_grids/customer/replace_group">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">customer-group-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/customer_index_index.xml
+++ b/view/adminhtml/layout/customer_index_index.xml
@@ -4,7 +4,7 @@
     <body>
         <referenceContainer name="content">
             <uiComponent name="customer_listing">
-                <visibilityCondition name="can_view_native_customer_listing" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\CanViewNativeCustomerListing"/>
+                <visibilityCondition name="can_view_native_customer_listing" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Customer\CanViewNativeCustomerListing"/>
             </uiComponent>
             <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="customer-grid" ifconfig="easy_admin_grids/customer/replace_listing">
                 <arguments>

--- a/view/adminhtml/layout/customer_online_index.xml
+++ b/view/adminhtml/layout/customer_online_index.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <uiComponent name="customer_online_grid">
+                <visibilityCondition name="can_view_native_customer_online_listing" className="Juashyam\EasyAdminGrids\Model\Condition\ListingVisibility\Customer\CanViewNativeCustomerOnlineListing"/>
+            </uiComponent>
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="customer-online-grid" ifconfig="easy_admin_grids/customer/replace_now_online">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">customer-online-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/customersegment_index_index.xml
+++ b/view/adminhtml/layout/customersegment_index_index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Customer\Customersegment" name="customersegment.container"/>
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="customer-segment-grid" ifconfig="easy_admin_grids/customer/replace_segment">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">customer-segment-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/layout/sales_rule_promo_quote_index.xml
+++ b/view/adminhtml/layout/sales_rule_promo_quote_index.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <update handle="hyva_admin_grid"/>
+    <body>
+        <referenceContainer name="content">
+            <block class="Juashyam\EasyAdminGrids\Block\Adminhtml\Grid" name="marketing-cart-rules-grid" ifconfig="easy_admin_grids/marketing/replace_cart_rule">
+                <arguments>
+                    <argument name="grid_name" xsi:type="string">marketing-cart-rules-grid</argument>
+                </arguments>
+            </block>
+        </referenceContainer>
+    </body>
+</page>


### PR DESCRIPTION
### Added
- Extends coverage of native grids under **Customers**
    - Replace `Now Online` Grid
    - Replace `Customers Group` Grid
    - Replace `Customers Segment` Grid
- Extends coverage of native grids under **Marketing**
    - Replace `Catalog Price Rule` Grid
    - Replace `Related Products Rules` Grid
    - Replace `Cart Price Rules` Grid
    - Replace `Gift Card Accounts` Grid
- New system configurations to enable/displace Hyva Admin grid replacement

### Changed
- Restructured the directory path for listing visibility classes to group relative ones

### Removed
- Nothing